### PR TITLE
AddLinqReferenceToUnitTest

### DIFF
--- a/Tailspin.SpaceGame.Web.Tests/DocumentDBRepository_GetItemsAsyncShould.cs
+++ b/Tailspin.SpaceGame.Web.Tests/DocumentDBRepository_GetItemsAsyncShould.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using NUnit.Framework;


### PR DESCRIPTION
I forgot to add a reference to System.Linq and therefore the project does not compile.